### PR TITLE
fix: adding `install protoc` into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
+            - name: Install Protoc
+              uses: arduino/setup-protoc@v1
             - name: Build project # This would actually build your project, using zip for an example artifact
               run: |
                   bash ./scripts/release.sh


### PR DESCRIPTION
Adding `install protoc` into release workflow to fix `cargo build` command error on `release.yml` 